### PR TITLE
Change No Score Exit Code to Success

### DIFF
--- a/pylint_fail_under/__main__.py
+++ b/pylint_fail_under/__main__.py
@@ -42,7 +42,7 @@ def main():
             score = results.linter.stats["global_note"]
         except KeyError:
             logger.error("no score parsed from Pylint output")
-            exit_code = NO_SCORE_PARSED
+            exit_code = SUCCESS
         else:
             if score < fail_under_value:
                 logger.error("score %s is less than fail-under value %s", score, fail_under_value)


### PR DESCRIPTION
The reasoning behind this is if you have a file with `# pylint: disable-all` or a file with no code (such as a fully commented out file), PyLint will not generate a score, however, that means does not mean you have an error value, but rather, just no value, so it should be a success.